### PR TITLE
Add toString to IPv4 and IPv6 addresses

### DIFF
--- a/src/main/java/com/github/hirsivaja/ip/ipv4/Ipv4Address.java
+++ b/src/main/java/com/github/hirsivaja/ip/ipv4/Ipv4Address.java
@@ -12,7 +12,7 @@ public class Ipv4Address implements IpAddress {
     private final byte[] addressBytes;
 
     public Ipv4Address(byte[] addressBytes) {
-        if(addressBytes.length != IPV4_ADDRESS_LEN) {
+        if (addressBytes.length != IPV4_ADDRESS_LEN) {
             throw new IllegalArgumentException("Incorrect length for IPv4 address " + addressBytes.length);
         }
         this.addressBytes = addressBytes;
@@ -51,11 +51,31 @@ public class Ipv4Address implements IpAddress {
     }
 
     public static Ipv4Address decode(ByteBuffer in) {
-        if(in.remaining() < IPV4_ADDRESS_LEN) {
+        if (in.remaining() < IPV4_ADDRESS_LEN) {
             throw new IllegalArgumentException("Too few remaining bytes " + in.remaining());
         }
         byte[] addressBytes = new byte[IPV4_ADDRESS_LEN];
         in.get(addressBytes);
         return new Ipv4Address(addressBytes);
+    }
+
+    /**
+     * Returns the standard dotted decimal string representation of the IPv4
+     * address.
+     * Format: "a.b.c.d" where each component is 0-255.
+     * Leading zeros are suppressed to avoid ambiguity with octal interpretation.
+     * Examples: "192.168.1.1", "127.0.0.1", "255.255.255.255"
+     */
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < 4; i++) {
+            if (i > 0) {
+                sb.append('.');
+            }
+            int octet = addressBytes[i] & 0xFF;
+            sb.append(octet);
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/github/hirsivaja/ip/ipv6/Ipv6Address.java
+++ b/src/main/java/com/github/hirsivaja/ip/ipv6/Ipv6Address.java
@@ -12,7 +12,7 @@ public class Ipv6Address implements IpAddress {
     private final byte[] addressBytes;
 
     public Ipv6Address(byte[] addressBytes) {
-        if(addressBytes.length != IPV6_ADDRESS_LEN) {
+        if (addressBytes.length != IPV6_ADDRESS_LEN) {
             throw new IllegalArgumentException("Incorrect length for IPv6 address " + addressBytes.length);
         }
         this.addressBytes = addressBytes;
@@ -47,11 +47,112 @@ public class Ipv6Address implements IpAddress {
     }
 
     public static Ipv6Address decode(ByteBuffer in) {
-        if(in.remaining() < IPV6_ADDRESS_LEN) {
+        if (in.remaining() < IPV6_ADDRESS_LEN) {
             throw new IllegalArgumentException("Too few remaining bytes " + in.remaining());
         }
         byte[] addressBytes = new byte[IPV6_ADDRESS_LEN];
         in.get(addressBytes);
         return new Ipv6Address(addressBytes);
     }
+
+    /**
+     * Returns the compressed IPv6 string representation (RFC 5952)
+     * <br>
+     * Examples: ::1, 2001:db8::1
+     */
+    public String toCompressedString() {
+        // Convert bytes to 16-bit groups
+        int[] groups = new int[8];
+        for (int i = 0; i < 8; i++) {
+            groups[i] = ((addressBytes[i * 2] & 0xFF) << 8) | (addressBytes[i * 2 + 1] & 0xFF);
+        }
+
+        // Find the longest sequence of consecutive zeros
+        int longestZeroStart = -1;
+        int longestZeroLength = 0;
+        int currentZeroStart = -1;
+        int currentZeroLength = 0;
+
+        for (int i = 0; i < 8; i++) {
+            if (groups[i] == 0) {
+                if (currentZeroStart == -1) {
+                    currentZeroStart = i;
+                    currentZeroLength = 1;
+                } else {
+                    currentZeroLength++;
+                }
+            } else {
+                if (currentZeroLength > longestZeroLength) {
+                    longestZeroStart = currentZeroStart;
+                    longestZeroLength = currentZeroLength;
+                }
+                currentZeroStart = -1;
+                currentZeroLength = 0;
+            }
+        }
+
+        // Check if the last sequence is the longest
+        if (currentZeroLength > longestZeroLength) {
+            longestZeroStart = currentZeroStart;
+            longestZeroLength = currentZeroLength;
+        }
+
+        // Build the compressed string
+        StringBuilder sb = new StringBuilder();
+
+        // Only compress if we have 2 or more consecutive zeros
+        if (longestZeroLength >= 2) {
+            // Before the compressed section
+            for (int i = 0; i < longestZeroStart; i++) {
+                if (i > 0)
+                    sb.append(':');
+                sb.append(Integer.toHexString(groups[i]));
+            }
+
+            // The compressed section
+            sb.append("::");
+
+            // After the compressed section
+            for (int i = longestZeroStart + longestZeroLength; i < 8; i++) {
+                if (i > longestZeroStart + longestZeroLength)
+                    sb.append(':');
+                sb.append(Integer.toHexString(groups[i]));
+            }
+        } else {
+            // No compression needed
+            for (int i = 0; i < 8; i++) {
+                if (i > 0)
+                    sb.append(':');
+                sb.append(Integer.toHexString(groups[i]));
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns the full uncompressed IPv6 string representation
+     * <br>
+     * Example: 2001:0db8:0000:0000:0000:0000:0000:0001
+     */
+    public String toFullString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < 8; i++) {
+            if (i > 0)
+                sb.append(':');
+
+            int group = ((addressBytes[i * 2] & 0xFF) << 8) | (addressBytes[i * 2 + 1] & 0xFF);
+            sb.append(String.format("%04x", group));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Default string representation uses compressed format
+     */
+    @Override
+    public String toString() {
+        return toCompressedString();
+    }
+
 }

--- a/src/test/java/com/github/hirsivaja/ip/ipv4/Ipv4AddressTest.java
+++ b/src/test/java/com/github/hirsivaja/ip/ipv4/Ipv4AddressTest.java
@@ -3,42 +3,193 @@ package com.github.hirsivaja.ip.ipv4;
 import com.github.hirsivaja.ip.IpUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
 
+@RunWith(Enclosed.class)
 public class Ipv4AddressTest {
-    @Test
-    public void addressTest() {
-        byte[] ipv4AddressBytes = IpUtils.parseHexBinary("01020304");
-        Ipv4Address address = Ipv4Address.decode(ByteBuffer.wrap(ipv4AddressBytes));
-        Assert.assertEquals(4, address.getLength());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.getAddress());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.toInetAddress().getAddress());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.toInet4Address().getAddress());
 
-        ipv4AddressBytes = IpUtils.parseHexBinary("00000000");
-        address = Ipv4Address.decode(ByteBuffer.wrap(ipv4AddressBytes));
-        Assert.assertEquals(4, address.getLength());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.getAddress());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.toInetAddress().getAddress());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.toInet4Address().getAddress());
+    public static class Ipv4AddressSingleTest {
+        @Test
+        public void addressTest() {
+            byte[] ipv4AddressBytes = IpUtils.parseHexBinary("01020304");
+            Ipv4Address address = Ipv4Address.decode(ByteBuffer.wrap(ipv4AddressBytes));
+            Assert.assertEquals(4, address.getLength());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.getAddress());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.toInetAddress().getAddress());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.toInet4Address().getAddress());
 
-        ipv4AddressBytes = IpUtils.parseHexBinary("FFFFFFFF");
-        address = Ipv4Address.decode(ByteBuffer.wrap(ipv4AddressBytes));
-        Assert.assertEquals(4, address.getLength());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.getAddress());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.toInetAddress().getAddress());
-        Assert.assertArrayEquals(ipv4AddressBytes, address.toInet4Address().getAddress());
+            ipv4AddressBytes = IpUtils.parseHexBinary("00000000");
+            address = Ipv4Address.decode(ByteBuffer.wrap(ipv4AddressBytes));
+            Assert.assertEquals(4, address.getLength());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.getAddress());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.toInetAddress().getAddress());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.toInet4Address().getAddress());
+
+            ipv4AddressBytes = IpUtils.parseHexBinary("FFFFFFFF");
+            address = Ipv4Address.decode(ByteBuffer.wrap(ipv4AddressBytes));
+            Assert.assertEquals(4, address.getLength());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.getAddress());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.toInetAddress().getAddress());
+            Assert.assertArrayEquals(ipv4AddressBytes, address.toInet4Address().getAddress());
+        }
+
+        @Test
+        public void invalidAddressTest() {
+            byte[] tooFewBytes = IpUtils.parseHexBinary("010203");
+            ByteBuffer tooFew = ByteBuffer.wrap(tooFewBytes);
+            Assert.assertThrows(IllegalArgumentException.class, () -> Ipv4Address.decode(tooFew));
+            Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv4Address(tooFewBytes));
+
+            byte[] tooManyBytes = IpUtils.parseHexBinary("0102030405");
+            Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv4Address(tooManyBytes));
+        }
     }
 
-    @Test
-    public void invalidAddressTest() {
-        byte[] tooFewBytes = IpUtils.parseHexBinary("010203");
-        ByteBuffer tooFew = ByteBuffer.wrap(tooFewBytes);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Ipv4Address.decode(tooFew));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv4Address(tooFewBytes));
+    @RunWith(Parameterized.class)
+    public static class Ipv4AddressParameterizedTest {
 
-        byte[] tooManyBytes = IpUtils.parseHexBinary("0102030405");
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv4Address(tooManyBytes));
+        private final String description;
+        private final byte[] input;
+        private final String expected;
+
+        public Ipv4AddressParameterizedTest(String description, byte[] input, String expected) {
+            this.description = description;
+            this.input = input;
+            this.expected = expected;
+        }
+
+        @Parameters(name = "{0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    // Basic edge cases
+                    {"All zeros",
+                            new byte[]{0, 0, 0, 0},
+                            "0.0.0.0"},
+
+                    {"All ones (broadcast)",
+                            new byte[]{(byte) 255, (byte) 255, (byte) 255, (byte) 255},
+                            "255.255.255.255"},
+
+                    {"Loopback address",
+                            new byte[]{127, 0, 0, 1},
+                            "127.0.0.1"},
+
+                    // Private network addresses
+                    {"Private network - Class A",
+                            new byte[]{10, 0, 0, 1},
+                            "10.0.0.1"},
+
+                    {"Private network - Class B",
+                            new byte[]{(byte) 172, 16, 0, 1},
+                            "172.16.0.1"},
+
+                    {"Private network - Class C",
+                            new byte[]{(byte) 192, (byte) 168, 1, 1},
+                            "192.168.1.1"},
+
+                    // Documentation addresses (RFC 5737)
+                    {"Documentation prefix (TEST-NET-1)",
+                            new byte[]{(byte) 192, 0, 2, 1},
+                            "192.0.2.1"},
+
+                    {"Documentation prefix (TEST-NET-2)",
+                            new byte[]{(byte) 198, 51, 100, 1},
+                            "198.51.100.1"},
+
+                    {"Documentation prefix (TEST-NET-3)",
+                            new byte[]{(byte) 203, 0, 113, 1},
+                            "203.0.113.1"},
+
+                    // Special purpose addresses
+
+                    {"Multicast address",
+                            new byte[]{(byte) 224, 0, 0, 1},
+                            "224.0.0.1"},
+
+                    {"Limited broadcast",
+                            new byte[]{(byte) 255, (byte) 255, (byte) 255, (byte) 255},
+                            "255.255.255.255"},
+
+                    // Class boundaries
+                    {"Class A maximum",
+                            new byte[]{127, (byte) 255, (byte) 255, (byte) 254},
+                            "127.255.255.254"},
+
+                    {"Class B start",
+                            new byte[]{(byte) 128, 0, 0, 1},
+                            "128.0.0.1"},
+
+                    {"Class C start",
+                            new byte[]{(byte) 192, 0, 0, 1},
+                            "192.0.0.1"},
+
+                    // Test signed byte handling (values 128-255)
+                    {"High value octets",
+                            new byte[]{(byte) 255, 0, (byte) 255, 0},
+                            "255.0.255.0"},
+
+                    {"Mixed high and low values",
+                            new byte[]{(byte) 203, 0, 113, (byte) 195},
+                            "203.0.113.195"},
+
+                    {"All high values",
+                            new byte[]{(byte) 240, (byte) 248, (byte) 252, (byte) 254},
+                            "240.248.252.254"},
+
+                    {"Common gateway",
+                            new byte[]{(byte) 192, (byte) 168, 1, (byte) 254},
+                            "192.168.1.254"},
+
+                    {"Common router",
+                            new byte[]{(byte) 192, (byte) 168, 0, 1},
+                            "192.168.0.1"},
+
+                    // Sequential and pattern testing
+                    {"Sequential values",
+                            new byte[]{1, 2, 3, 4},
+                            "1.2.3.4"},
+
+                    {"Power of 2 values",
+                            new byte[]{1, 2, 4, 8},
+                            "1.2.4.8"},
+
+                    {"128 values (MSB set)",
+                            new byte[]{(byte) 128, (byte) 128, (byte) 128, (byte) 128},
+                            "128.128.128.128"},
+
+                    {"Alternating pattern",
+                            new byte[]{(byte) 170, 85, (byte) 170, 85},
+                            "170.85.170.85"},
+
+                    // Leading zero suppression test cases
+                    {"Single digits",
+                            new byte[]{1, 2, 3, 4},
+                            "1.2.3.4"},
+
+                    {"Mixed digit counts",
+                            new byte[]{10, 100, 1, (byte) 200},
+                            "10.100.1.200"},
+
+                    {"No leading zeros",
+                            new byte[]{123, 45, 67, 89},
+                            "123.45.67.89"}
+            });
+        }
+
+        @Test
+        public void ipv4AddressToStringTest() {
+            Ipv4Address addr = new Ipv4Address(input);
+            assertEquals("Decimal conversion failed for: " + description,
+                    expected, addr.toString());
+        }
     }
 }

--- a/src/test/java/com/github/hirsivaja/ip/ipv6/Ipv6AddressTest.java
+++ b/src/test/java/com/github/hirsivaja/ip/ipv6/Ipv6AddressTest.java
@@ -3,42 +3,212 @@ package com.github.hirsivaja.ip.ipv6;
 import com.github.hirsivaja.ip.IpUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
 
+@RunWith(Enclosed.class)
 public class Ipv6AddressTest {
-    @Test
-    public void addressTest() {
-        byte[] ipv6AddressBytes = IpUtils.parseHexBinary("0102030405060708090A0B0C0D0E0F00");
-        Ipv6Address address = Ipv6Address.decode(ByteBuffer.wrap(ipv6AddressBytes));
-        Assert.assertEquals(16, address.getLength());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.getAddress());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.toInetAddress().getAddress());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.toInet6Address().getAddress());
 
-        ipv6AddressBytes = IpUtils.parseHexBinary("00000000000000000000000000000000");
-        address = Ipv6Address.decode(ByteBuffer.wrap(ipv6AddressBytes));
-        Assert.assertEquals(16, address.getLength());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.getAddress());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.toInetAddress().getAddress());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.toInet6Address().getAddress());
+    public static class Ipv6AddressSingleTest {
+        @Test
+        public void addressTest() {
+            byte[] ipv6AddressBytes = IpUtils.parseHexBinary("0102030405060708090A0B0C0D0E0F00");
+            Ipv6Address address = Ipv6Address.decode(ByteBuffer.wrap(ipv6AddressBytes));
+            Assert.assertEquals(16, address.getLength());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.getAddress());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.toInetAddress().getAddress());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.toInet6Address().getAddress());
 
-        ipv6AddressBytes = IpUtils.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
-        address = Ipv6Address.decode(ByteBuffer.wrap(ipv6AddressBytes));
-        Assert.assertEquals(16, address.getLength());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.getAddress());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.toInetAddress().getAddress());
-        Assert.assertArrayEquals(ipv6AddressBytes, address.toInet6Address().getAddress());
+            ipv6AddressBytes = IpUtils.parseHexBinary("00000000000000000000000000000000");
+            address = Ipv6Address.decode(ByteBuffer.wrap(ipv6AddressBytes));
+            Assert.assertEquals(16, address.getLength());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.getAddress());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.toInetAddress().getAddress());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.toInet6Address().getAddress());
+
+            ipv6AddressBytes = IpUtils.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+            address = Ipv6Address.decode(ByteBuffer.wrap(ipv6AddressBytes));
+            Assert.assertEquals(16, address.getLength());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.getAddress());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.toInetAddress().getAddress());
+            Assert.assertArrayEquals(ipv6AddressBytes, address.toInet6Address().getAddress());
+        }
+
+        @Test
+        public void invalidAddressTest() {
+            byte[] tooFewBytes = IpUtils.parseHexBinary("01020304");
+            ByteBuffer tooFew = ByteBuffer.wrap(tooFewBytes);
+            Assert.assertThrows(IllegalArgumentException.class, () -> Ipv6Address.decode(tooFew));
+            Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv6Address(tooFewBytes));
+
+            byte[] tooManyBytes = IpUtils.parseHexBinary("0102030405060708090A0B0C0D0E0F0001020304");
+            Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv6Address(tooManyBytes));
+        }
     }
 
-    @Test
-    public void invalidAddressTest() {
-        byte[] tooFewBytes = IpUtils.parseHexBinary("01020304");
-        ByteBuffer tooFew = ByteBuffer.wrap(tooFewBytes);
-        Assert.assertThrows(IllegalArgumentException.class, () -> Ipv6Address.decode(tooFew));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv6Address(tooFewBytes));
+    @RunWith(Parameterized.class)
+    public static class Ipv6AddressParameterizedTest {
 
-        byte[] tooManyBytes = IpUtils.parseHexBinary("0102030405060708090A0B0C0D0E0F0001020304");
-        Assert.assertThrows(IllegalArgumentException.class, () -> new Ipv6Address(tooManyBytes));
+        private final String description;
+        private final byte[] input;
+        private final String expectedCompressed;
+        private final String expectedFull;
+
+        public Ipv6AddressParameterizedTest(String description, byte[] input,
+                                            String expectedCompressed, String expectedFull) {
+            this.description = description;
+            this.input = input;
+            this.expectedCompressed = expectedCompressed;
+            this.expectedFull = expectedFull;
+        }
+
+        @Parameters(name = "{0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    // Basic edge cases
+                    {"All zeros",
+                            new byte[16],
+                            "::",
+                            "0000:0000:0000:0000:0000:0000:0000:0000"},
+
+                    {"Loopback address",
+                            new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+                            "::1",
+                            "0000:0000:0000:0000:0000:0000:0000:0001"},
+
+                    // No compression scenarios
+                    {"No compression needed - no consecutive zeros",
+                            new byte[]{0x20, 0x01, 0x0d, (byte) 0xb8, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04,
+                                    0x00, 0x05, 0x00, 0x06},
+                            "2001:db8:1:2:3:4:5:6",
+                            "2001:0db8:0001:0002:0003:0004:0005:0006"},
+
+                    {"Single zero groups should not be compressed",
+                            new byte[]{0x20, 0x01, 0x00, 0x00, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+                                    0x00, 0x02, 0x00, 0x03},
+                            "2001:0:db8:0:1:0:2:3",
+                            "2001:0000:0db8:0000:0001:0000:0002:0003"},
+
+                    // Zero sequences at different positions
+                    {"Zeros at the beginning",
+                            new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
+                                    0x03, 0x00, 0x04},
+                            "::1:2:3:4",
+                            "0000:0000:0000:0000:0001:0002:0003:0004"},
+
+                    {"Zeros at the end",
+                            new byte[]{0x20, 0x01, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00},
+                            "2001:db8::",
+                            "2001:0db8:0000:0000:0000:0000:0000:0000"},
+
+                    {"Zeros in the middle",
+                            new byte[]{0x20, 0x01, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x01},
+                            "2001:db8::1",
+                            "2001:0db8:0000:0000:0000:0000:0000:0001"},
+
+                    // Multiple zero sequences
+                    {"Multiple zero sequences - compress longest",
+                            new byte[]{0x20, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x01},
+                            "2001:0:0:db8::1",
+                            "2001:0000:0000:0db8:0000:0000:0000:0001"},
+
+                    {"Equal length zero sequences - compress first occurrence",
+                            new byte[]{0x20, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x01, 0x00, 0x02},
+                            "2001::db8:0:0:1:2",
+                            "2001:0000:0000:0db8:0000:0000:0001:0002"},
+
+                    {"Exactly two consecutive zeros",
+                            new byte[]{0x20, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0d, (byte) 0xb8, 0x00, 0x01, 0x00, 0x02,
+                                    0x00, 0x03, 0x00, 0x04},
+                            "2001::db8:1:2:3:4",
+                            "2001:0000:0000:0db8:0001:0002:0003:0004"},
+
+                    // Formatting tests
+                    {"Maximum values in groups",
+                            new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                                    (byte) 0xFF, (byte) 0xFF,
+                                    (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                                    (byte) 0xFF, (byte) 0xFF},
+                            "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+                            "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+
+                    {"Mixed case should be lowercase",
+                            new byte[]{(byte) 0xAB, (byte) 0xCD, (byte) 0xEF, 0x12, 0x34, 0x56, 0x78, (byte) 0x9A,
+                                    (byte) 0xBC, (byte) 0xDE, (byte) 0xF0, 0x11, 0x22, 0x33, 0x44, 0x55},
+                            "abcd:ef12:3456:789a:bcde:f011:2233:4455",
+                            "abcd:ef12:3456:789a:bcde:f011:2233:4455"},
+
+                    {"Leading zeros should be omitted in compressed format",
+                            new byte[]{0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00,
+                                    0x07, 0x00, 0x08},
+                            "1:2:3:4:5:6:7:8",
+                            "0001:0002:0003:0004:0005:0006:0007:0008"},
+
+                    // Real-world address types
+                    {"Link-local prefix",
+                            new byte[]{(byte) 0xfe, (byte) 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+                            "fe80::1",
+                            "fe80:0000:0000:0000:0000:0000:0000:0001"},
+
+                    {"Documentation prefix",
+                            new byte[]{0x20, 0x01, 0x0d, (byte) 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+                            "2001:db8::1",
+                            "2001:0db8:0000:0000:0000:0000:0000:0001"},
+
+                    {"Multicast prefix",
+                            new byte[]{(byte) 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+                            "ff02::1",
+                            "ff02:0000:0000:0000:0000:0000:0000:0001"},
+
+                    // Edge cases for zero sequence detection
+                    {"Alternating single zeros",
+                            new byte[]{0x20, 0x01, 0x00, 0x00, 0x0d, (byte) 0xb8, 0x00, 0x00, 0x12, 0x34, 0x00, 0x00,
+                                    0x56, 0x78, 0x00, 0x00},
+                            "2001:0:db8:0:1234:0:5678:0",
+                            "2001:0000:0db8:0000:1234:0000:5678:0000"},
+
+                    {"Three zero groups at start",
+                            new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x01, 0x0d, (byte) 0xb8, 0x00, 0x01,
+                                    0x00, 0x02, 0x00, 0x03},
+                            "::2001:db8:1:2:3",
+                            "0000:0000:0000:2001:0db8:0001:0002:0003"},
+
+                    {"Three zero groups at end",
+                            new byte[]{0x20, 0x01, 0x0d, (byte) 0xb8, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00},
+                            "2001:db8:1::",
+                            "2001:0db8:0001:0000:0000:0000:0000:0000"},
+
+                    {"All groups have leading zeros",
+                            new byte[]{0x00, 0x12, 0x00, 0x34, 0x00, 0x56, 0x00, 0x78, 0x00, (byte) 0x9a, 0x00,
+                                    (byte) 0xbc, 0x00, (byte) 0xde, 0x00, (byte) 0xf0},
+                            "12:34:56:78:9a:bc:de:f0",
+                            "0012:0034:0056:0078:009a:00bc:00de:00f0"}
+            });
+        }
+
+        @Test
+        public void ipv6AddressToStringTest() {
+            Ipv6Address addr = new Ipv6Address(input);
+            assertEquals("Compressed format failed for: " + description,
+                    expectedCompressed, addr.toCompressedString());
+            assertEquals("Full format failed for: " + description,
+                    expectedFull, addr.toFullString());
+            assertEquals("toString() should return compressed format for: " + description,
+                    expectedCompressed, addr.toString());
+        }
     }
+
 }


### PR DESCRIPTION
- By default the toString for IPv6 uses the compressed representation

See #1 for discussion